### PR TITLE
fix(docker): remove invalid 'name' property from external network dec…

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -222,5 +222,4 @@ networks:
     name: podigger-production
     driver: bridge
   podigger-proxy:
-    name: podigger-proxy
     external: true

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -164,5 +164,4 @@ networks:
     name: podigger-staging
     driver: bridge
   podigger-proxy:
-    name: podigger-proxy
     external: true

--- a/nginx-proxy/docker-compose.yml
+++ b/nginx-proxy/docker-compose.yml
@@ -30,7 +30,6 @@ services:
 
 networks:
   podigger-proxy:
-    name: podigger-proxy
     external: true
 
 volumes:


### PR DESCRIPTION
…larations

This fixes errors under older docker-compose versions where explicitly naming an external network inside the 'external: true' block causes 'network declared as external, but could not be found' during deployment.